### PR TITLE
Fix minperf calculation when there are NaNs

### DIFF
--- a/src/performance_profiles.jl
+++ b/src/performance_profiles.jl
@@ -15,7 +15,7 @@ function performance_ratios(T :: Array{Float64,2}; logscale :: Bool=true)
 
   T[isinf.(T)] = NaN;
   T[T .< 0] = NaN;
-  minperf = Base.minimum(T, 2);  # Minimal (i.e., best) performance per solver
+  minperf = mapslices(NaNMath.minimum, T, 2) # Minimal (i.e., best) performance per solver
 
   # Compute ratios and divide by smallest element in each row.
   r = zeros(np, ns);


### PR DESCRIPTION
Currently, all solvers are considered "failed" for a particular problem, if one of them has failed.
We need to use NaNMath instead of Base to calculate the minimum.

PS: can you also tag a new version after this fix, please?