### PR TITLE
Downsample performance profiles

### DIFF
--- a/src/performance_profiles.jl
+++ b/src/performance_profiles.jl
@@ -59,15 +59,15 @@ function performance_profile(T :: Array{Float64,2}, labels :: Vector{AbstractStr
   profile = Plots.plot(; kwargs...)  # initial empty plot
   for s = 1 : ns
     rs = view(ratios,:,s)
-      urs = unique(rs)
-      @show length(urs)
+    urs = unique(rs)
+    @show length(urs)
     xidx = zeros(Int,length(urs)+1)
     k = 0
-    rv = minimum(rs)
-    while rv < maximum(urs)
+    rv = log2(minimum(rs))
+    while rv < log2(maximum(urs))
       k += 1
-      xidx[k] = findlast(rs .<= rv)
-      rv = max(rs[xidx[k]]+sampletol,rs[xidx[k]+1])
+      xidx[k] = findlast(log2.(rs) .<= rv)
+      rv = max(log2(rs[xidx[k]])+sampletol, log2(rs[xidx[k]+1]))
     end
     xidx[k+1] = length(rs)
     xidx = xidx[xidx .> 0]

--- a/src/performance_profiles.jl
+++ b/src/performance_profiles.jl
@@ -47,7 +47,7 @@ performance plot.
 function performance_profile(T :: Array{Float64,2}, labels :: Vector{AbstractString};
                              logscale :: Bool=true,
                              title :: AbstractString="",
-                             sampletol :: Float64 = 5e-2,
+                             sampletol :: Float64 = 0.0,
                              kwargs...)
 
   (ratios, max_ratio) = performance_ratios(T, logscale=logscale)
@@ -59,36 +59,22 @@ function performance_profile(T :: Array{Float64,2}, labels :: Vector{AbstractStr
   profile = Plots.plot(; kwargs...)  # initial empty plot
   for s = 1 : ns
     rs = view(ratios,:,s)
-    urs = unique(rs)
-    @show length(urs)
-    xidx = zeros(Int,length(urs)+1)
+    xidx = zeros(Int,length(rs)+1)
     k = 0
-    rv = minimum(urs)
-    maxval = maximum(urs)
-    if logscale == false
-      # I will just use the logscale in Plots instead
-      rv = log2(rv)
-      maxval = log2(maxval)
-    end
-
+    rv = minimum(rs)
+    maxval = maximum(rs)
     while rv < maxval
       k += 1
-      if logscale == true
-        xidx[k] = findlast(rs .<= rv)
-        rv = max(rs[xidx[k]] + sampletol, rs[xidx[k]+1])
-      else
-        xidx[k] = findlast(log2.(rs) .<= rv)
-        rv = max(log2(rs[xidx[k]])+sampletol, log2(rs[xidx[k]+1]))
-      end
+      xidx[k] = findlast(rs .<= rv)
+      rv = max(rs[xidx[k]] + sampletol, rs[xidx[k]+1])
     end
     xidx[k+1] = length(rs)
     xidx = xidx[xidx .> 0]
     xidx = unique(xidx) # Needed?
-    @show length(xidx)
     Plots.plot!(rs[xidx], xs[xidx], t=:steppost, label=labels[s])
   end
- #Plots.xlims!(logscale ? 0.0 : 1.0, 1.1 * max_ratio)
-  #Plots.ylims!(0, 1.1)
+  Plots.xlims!(logscale ? 0.0 : 1.0, 1.1 * max_ratio)
+  Plots.ylims!(0, 1.1)
   Plots.xlabel!("Within this factor of the best" * (logscale ? " (log scale)" : ""))
   Plots.ylabel!("Proportion of problems")
   Plots.title!(title)

--- a/src/performance_profiles.jl
+++ b/src/performance_profiles.jl
@@ -47,6 +47,7 @@ performance plot.
 function performance_profile(T :: Array{Float64,2}, labels :: Vector{AbstractString};
                              logscale :: Bool=true,
                              title :: AbstractString="",
+                             sampletol :: Float64 = 5e-2,
                              kwargs...)
 
   (ratios, max_ratio) = performance_ratios(T, logscale=logscale)
@@ -57,10 +58,25 @@ function performance_profile(T :: Array{Float64,2}, labels :: Vector{AbstractStr
   length(labels) == 0 && (labels = [@sprintf("column %d", col) for col = 1 : ns])
   profile = Plots.plot(; kwargs...)  # initial empty plot
   for s = 1 : ns
-    Plots.plot!(ratios[:, s], xs, t=:steppost, label=labels[s])
+    rs = view(ratios,:,s)
+      urs = unique(rs)
+      @show length(urs)
+    xidx = zeros(Int,length(urs)+1)
+    k = 0
+    rv = minimum(rs)
+    while rv < maximum(urs)
+      k += 1
+      xidx[k] = findlast(rs .<= rv)
+      rv = max(rs[xidx[k]]+sampletol,rs[xidx[k]+1])
+    end
+    xidx[k+1] = length(rs)
+    xidx = xidx[xidx .> 0]
+    xidx = unique(xidx) # Needed?
+    @show length(xidx)
+    Plots.plot!(rs[xidx], xs[xidx], t=:steppost, label=labels[s])
   end
-  Plots.xlims!(logscale ? 0.0 : 1.0, 1.1 * max_ratio)
-  Plots.ylims!(0, 1.1)
+ #Plots.xlims!(logscale ? 0.0 : 1.0, 1.1 * max_ratio)
+  #Plots.ylims!(0, 1.1)
   Plots.xlabel!("Within this factor of the best" * (logscale ? " (log scale)" : ""))
   Plots.ylabel!("Proportion of problems")
   Plots.title!(title)

--- a/src/performance_profiles.jl
+++ b/src/performance_profiles.jl
@@ -63,11 +63,23 @@ function performance_profile(T :: Array{Float64,2}, labels :: Vector{AbstractStr
     @show length(urs)
     xidx = zeros(Int,length(urs)+1)
     k = 0
-    rv = log2(minimum(rs))
-    while rv < log2(maximum(urs))
+    rv = minimum(urs)
+    maxval = maximum(urs)
+    if logscale == false
+      # I will just use the logscale in Plots instead
+      rv = log2(rv)
+      maxval = log2(maxval)
+    end
+
+    while rv < maxval
       k += 1
-      xidx[k] = findlast(log2.(rs) .<= rv)
-      rv = max(log2(rs[xidx[k]])+sampletol, log2(rs[xidx[k]+1]))
+      if logscale == true
+        xidx[k] = findlast(rs .<= rv)
+        rv = max(rs[xidx[k]] + sampletol, rs[xidx[k]+1])
+      else
+        xidx[k] = findlast(log2.(rs) .<= rv)
+        rv = max(log2(rs[xidx[k]])+sampletol, log2(rs[xidx[k]+1]))
+      end
     end
     xidx[k+1] = length(rs)
     xidx = xidx[xidx .> 0]


### PR DESCRIPTION
This enables a simple downsampling of data points along the x-axis for performance profiles. This also gets rid of the first vertical line at `x=1`, which goes from `y=1/np` to `perf_prof(1)`

I have run performance profiles on 18 000 problems, with six solvers. So the number of data points plotted gets extraordinarily large, and in particular impractical when plotting to PGF.

I don't know whether this is useful for anybody else, but putting up a PR just in case.