### PR TITLE
bump Plots version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BenchmarkProfiles"
 uuid = "ecbce9bc-3e5e-569d-9e29-55181f61f8d0"
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 NaNMath = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
@@ -9,7 +9,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
 NaNMath = "0.3"
-Plots = "0.19, 0.20, 0.21, 0.22, 0.23, 0.24, 0.25, 0.26, 0.27, 0.28, 0.29, 1.0"
+Plots = "1.2, 1.3, 1.4"
 julia = "0.7.0, 1"
 
 [extras]


### PR DESCRIPTION
This avoids an error message in SolverBenchmark that was fixed in a recent version of Plots.