### PR TITLE
Use 2^ for log2 x-axis

### DIFF
--- a/src/BenchmarkProfiles.jl
+++ b/src/BenchmarkProfiles.jl
@@ -28,6 +28,12 @@ end
 
 include("performance_profiles.jl")
 include("data_profiles.jl")
+
+function powertick(s::AbstractString)
+  codes = Dict(collect(".1234567890") .=> collect("⋅¹²³⁴⁵⁶⁷⁸⁹⁰"))
+  return "2" * map(c -> codes[c], s) # powertick("15") = 2¹⁵ and powertick(2.1) = "2²⋅¹"
+end
+
 include("requires.jl")
 
 end

--- a/src/requires.jl
+++ b/src/requires.jl
@@ -34,6 +34,12 @@ function __init__()
         end
         Plots.plot!(x_plot[s], y_plot[s], t = :steppost, label = labels[s]; kwargs...)  # add to initial plot
       end
+      if logscale
+        for xt in Plots.xticks(profile)
+          Plots.plot!(xticks = (xt[1], map(x -> powertick(x), xt[2])))
+          Plots.plot!(xtickfontsize=10)
+        end
+      end
       return profile
     end
 


### PR DESCRIPTION
#70 

I used `Plots.plot!(xtickfontsize=10)` because the fontsize is slightly smaller when we do the power.

![test_plots](https://user-images.githubusercontent.com/25304288/147125304-234e278c-922f-4676-ad14-37b0c605561c.png)

