### PR TITLE
add powertick for LaTeXStrings

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,11 +3,13 @@ uuid = "ecbce9bc-3e5e-569d-9e29-55181f61f8d0"
 version = "0.4.0"
 
 [deps]
+LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 NaNMath = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
+LaTeXStrings = "^1.3"
 NaNMath = "0.3, 1"
 Requires = "1"
 julia = "^1.6"

--- a/src/BenchmarkProfiles.jl
+++ b/src/BenchmarkProfiles.jl
@@ -1,5 +1,6 @@
 module BenchmarkProfiles
 
+using LaTeXStrings
 import NaNMath
 using Requires
 using Printf
@@ -29,9 +30,35 @@ end
 include("performance_profiles.jl")
 include("data_profiles.jl")
 
+"""
+Replace each number by 2^{number} in a string.
+Useful to transform axis ticks when plotting in log-base 2.
+
+Examples:
+
+    powertick("15") == "2¹⁵"
+    powertick("2.1") == "2²⋅¹"
+"""
 function powertick(s::AbstractString)
   codes = Dict(collect(".1234567890") .=> collect("⋅¹²³⁴⁵⁶⁷⁸⁹⁰"))
-  return "2" * map(c -> codes[c], s) # powertick("15") = 2¹⁵ and powertick(2.1) = "2²⋅¹"
+  return "2" * map(c -> codes[c], s)
+end
+
+"""
+Replace each number by 2^{number} in LaTeXStrings.
+Useful to transform axis ticks when plotting in log-base 2.
+
+Examples:
+
+    powertick(L"\$15\$") == L"\$2^{15}\$"
+    powertick(L"\$2.1\$") == L"\$2^{2.1}\$"
+"""
+function powertick(s::LaTeXString)
+  ex = r"[0-9.]+"
+  for m ∈ eachmatch(ex, s)
+    s = LaTeXString(replace(s, m.match => "2^{$(m.match)}"))
+  end
+  return s
 end
 
 include("requires.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,13 @@
 using BenchmarkProfiles
+using LaTeXStrings
 using Test
+
+@testset "powertick" begin
+  @test BenchmarkProfiles.powertick("15") == "2¹⁵"
+  @test BenchmarkProfiles.powertick("2.1") == "2²⋅¹"
+  @test BenchmarkProfiles.powertick(L"$15$") == L"$2^{15}$"
+  @test BenchmarkProfiles.powertick(L"$2.1$") == L"$2^{2.1}$"
+end
 
 @testset "No backend" begin
   T = 10 * rand(25, 3)


### PR DESCRIPTION
This missing method was causing an error in the SolverBenchmark docs because PyPlot returns xticks as LaTeXStrings (apparently).