### PR TITLE
Add powertick for hidden LaTeX

### DIFF
--- a/src/BenchmarkProfiles.jl
+++ b/src/BenchmarkProfiles.jl
@@ -39,10 +39,20 @@ Examples:
 
     powertick("15") == "2¹⁵"
     powertick("2.1") == "2²⋅¹"
+    powertick("\$0\$") == "\$2^0\$"
 """
 function powertick(s::AbstractString)
   codes = Dict(collect(".1234567890") .=> collect("⋅¹²³⁴⁵⁶⁷⁸⁹⁰"))
-  return "2" * map(c -> codes[c], s)
+  hidden_latex = !isnothing(match(r"^\$.*\$$", s))
+  ex = r"[0-9.]+"
+  for m ∈ eachmatch(ex, s)
+    s = if hidden_latex
+      replace(s, m.match => "2^{$(m.match)}")
+    else
+      replace(s, m.match => "2" * map(c -> codes[c], m.match))
+    end
+  end
+  return s
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,8 @@ using Test
 @testset "powertick" begin
   @test BenchmarkProfiles.powertick("15") == "2¹⁵"
   @test BenchmarkProfiles.powertick("2.1") == "2²⋅¹"
+  @test BenchmarkProfiles.powertick("\$15\$") == "\$2^{15}\$"
+  @test BenchmarkProfiles.powertick("\$2.1\$") == "\$2^{2.1}\$"
   @test BenchmarkProfiles.powertick(L"$15$") == L"$2^{15}$"
   @test BenchmarkProfiles.powertick(L"$2.1$") == L"$2^{2.1}$"
 end


### PR DESCRIPTION
Close #89 

```
using BenchmarkProfiles, Random, Plots, PyPlot
pyplot()

T = 200000 * rand(450, 3);
p = performance_profile(PlotsBackend(), T, ["Solver 1", "Solver 2", "Solver 3"]);
Plots.svg(p, "profile1")
```